### PR TITLE
Don't clear out newModelValue or newOptions prematurely

### DIFF
--- a/angular-selectize.js
+++ b/angular-selectize.js
@@ -104,8 +104,6 @@
             selected.forEach(function(item) {
               selectize.addItem(item);
             });
-            newModelValue = null;
-            newOptions = null;
             updateTimer = null;
           });
         }


### PR DESCRIPTION
This fixes a timing bug where the options load before the model and are cleared out before they can be displayed in the select box.
