### PR TITLE
Sync classes

### DIFF
--- a/angular-selectize.js
+++ b/angular-selectize.js
@@ -130,6 +130,8 @@
               //wait to remove ? to avoid a single select from briefly setting the model to null
               selectize.removeOption('?');
 
+              syncInputClasses();
+
               var $option = selectize.getOption(0);
               if ($option) selectize.setActiveOption($option);
             }
@@ -154,6 +156,24 @@
               }
             }
           });
+        }
+
+        function syncInputClasses() {
+          var inputClasses = selectize.$input.attr('class').split(' ');
+          var controlClasses = selectize.$control.attr('class').split(' ');
+          var i;
+
+          for (i=0; i < controlClasses.length; i++) {
+            if (controlClasses[i].match(/^ng\-/)) {
+              selectize.$control.removeClass(controlClasses[i]);
+            }
+          }
+
+          for (i=0; i < inputClasses.length; i++) {
+            if (inputClasses[i].match(/^ng\-/)) {
+              selectize.$control.addClass(inputClasses[i]);
+            }
+          }
         }
 
         function onItemAddMultiSelect(value, $item) {

--- a/angular-selectize.js
+++ b/angular-selectize.js
@@ -147,6 +147,7 @@
             initializing = false;
             element.selectize(opts);
             selectize = element[0].selectize;
+            syncInputClasses();
             if (attrs.ngOptions) {
               if (scope.multiple) {
                 selectize.on('item_add', onItemAddMultiSelect);

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -55,7 +55,7 @@ describe('<select selectize>', function() {
         });
 
         it('should copy the angular classes from the <select> into the selectize-input', function () {
-          var ngClasses = selectize.$wrapper.attr('classes').split(' ').filter(function (className) {
+          var ngClasses = selectize.$wrapper.attr('class').split(' ').filter(function (className) {
             return className.match(/^ng\-/);
           });
 
@@ -100,7 +100,7 @@ describe('<select selectize>', function() {
         });
 
         it('should the selectize-input angular classes', function () {
-          var ngClasses = selectize.$wrapper.attr('classes').split(' ').filter(function (className) {
+          var ngClasses = selectize.$wrapper.attr('class').split(' ').filter(function (className) {
             return className.match(/^ng\-/);
           });
 

--- a/test/select.spec.js
+++ b/test/select.spec.js
@@ -54,6 +54,16 @@ describe('<select selectize>', function() {
           assert.ok(selectize.$wrapper.hasClass('selectize-control'));
         });
 
+        it('should copy the angular classes from the <select> into the selectize-input', function () {
+          var ngClasses = selectize.$wrapper.attr('classes').split(' ').filter(function (className) {
+            return className.match(/^ng\-/);
+          });
+
+          ngClasses.forEach(function (className) {
+            assert.ok(selectize.$control.hasClass(className));
+          });
+        });
+
         it('should have the same number of options in the dropdown menu as DOM options', function() {
           assert.strictEqual(selectize.$dropdown_content.children().length, stringOptions.length);
         });
@@ -87,6 +97,16 @@ describe('<select selectize>', function() {
           scope.$apply();
           timeout.flush();
           testSelectedOption('bar');
+        });
+
+        it('should the selectize-input angular classes', function () {
+          var ngClasses = selectize.$wrapper.attr('classes').split(' ').filter(function (className) {
+            return className.match(/^ng\-/);
+          });
+
+          ngClasses.forEach(function (className) {
+            assert.ok(selectize.$control.hasClass(className));
+          });
         });
       });
     });


### PR DESCRIPTION
Keeps the `$control` classes synced up with the `$input`.

This is especially useful when using the Bootstrap 3 theme.

With this change, users can apply styles to the input on `.ng-dirty.ng-invalid` like this, for example:

``` css
input.ng-dirty.ng-invalid,
textarea.ng-dirty.ng-invalid,
select.ng-dirty.ng-invalid,
.selectize-input.ng-dirty.ng-invalid {
  border-color: @state-danger-bg !important;
}
```
