### PR TITLE
Use point matcher in bower config

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,10 +30,10 @@
   ],
   "dependencies": {
     "selectize": ">= 0.10.1 < 0.12.0",
-    "angular": "~1.2.5"
+    "angular": "<=1.2.25"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.5",
+    "angular-mocks": "<=1.2.25",
     "jquery": "^2.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -30,10 +30,10 @@
   ],
   "dependencies": {
     "selectize": ">= 0.10.1 < 0.12.0",
-    "angular": "^1.2.5"
+    "angular": "~1.2.5"
   },
   "devDependencies": {
-    "angular-mocks": "^1.2.5",
+    "angular-mocks": "~1.2.5",
     "jquery": "^2.1.0"
   }
 }


### PR DESCRIPTION
This library has many failing tests with angular 1.3 - see #28 

This locks the version at angular version at 1.2. If it does indeed work with 1.3, the tests should be fixed to reflect this.
